### PR TITLE
Suggests pkg-config in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ how to install Howl from source.
 based system).
 - `C compiler`: Howl has a very small C core itself, and it embeds
 dependencies written in C.
+- `pkg-config`: Helper tool for finding libraries.
 
 ### Build && install
 


### PR DESCRIPTION
I was stucked in compiling because my freshly installed Archlinux did not include pkg-config.